### PR TITLE
Use regular expression literals instead of pattern strings

### DIFF
--- a/Chapter_06/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
+++ b/Chapter_06/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
@@ -46,14 +46,14 @@ export class CountryEditComponent {
       iso2: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{2}')
+          Validators.pattern(/[a-zA-Z]{2}/)
         ],
         this.isDupeField("iso2")
       ],
       iso3: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{3}')
+          Validators.pattern(/[a-zA-Z]{3}/)
         ],
         this.isDupeField("iso3")
       ]

--- a/Chapter_07/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
+++ b/Chapter_07/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
@@ -48,11 +48,11 @@ export class CityEditComponent
       name: new FormControl('', Validators.required),
       lat: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       lon: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       countryId: new FormControl('', Validators.required)
     }, null, this.isDupeCity());

--- a/Chapter_07/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
+++ b/Chapter_07/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
@@ -48,14 +48,14 @@ export class CountryEditComponent
       iso2: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{2}')
+          Validators.pattern(/[a-zA-Z]{2}/)
         ],
         this.isDupeField("iso2")
       ],
       iso3: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{3}')
+          Validators.pattern(/[a-zA-Z]{3}/)
         ],
         this.isDupeField("iso3")
       ]

--- a/Chapter_08/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
+++ b/Chapter_08/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
@@ -51,11 +51,11 @@ export class CityEditComponent
       name: new FormControl('', Validators.required),
       lat: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       lon: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       countryId: new FormControl('', Validators.required)
     }, null, this.isDupeCity());

--- a/Chapter_08/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
+++ b/Chapter_08/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
@@ -48,14 +48,14 @@ export class CountryEditComponent
       iso2: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{2}')
+          Validators.pattern(/[a-zA-Z]{2}/)
         ],
         this.isDupeField("iso2")
       ],
       iso3: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{3}')
+          Validators.pattern(/[a-zA-Z]{3}/)
         ],
         this.isDupeField("iso3")
       ]

--- a/Chapter_09/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
+++ b/Chapter_09/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
@@ -51,11 +51,11 @@ export class CityEditComponent
       name: new FormControl('', Validators.required),
       lat: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       lon: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       countryId: new FormControl('', Validators.required)
     }, null, this.isDupeCity());

--- a/Chapter_09/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
+++ b/Chapter_09/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
@@ -48,14 +48,14 @@ export class CountryEditComponent
       iso2: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{2}')
+          Validators.pattern(/[a-zA-Z]{2}/)
         ],
         this.isDupeField("iso2")
       ],
       iso3: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{3}')
+          Validators.pattern(/[a-zA-Z]{3}/)
         ],
         this.isDupeField("iso3")
       ]

--- a/Chapter_10/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
+++ b/Chapter_10/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
@@ -51,11 +51,11 @@ export class CityEditComponent
       name: new FormControl('', Validators.required),
       lat: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       lon: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       countryId: new FormControl('', Validators.required)
     }, null, this.isDupeCity());

--- a/Chapter_10/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
+++ b/Chapter_10/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
@@ -48,14 +48,14 @@ export class CountryEditComponent
       iso2: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{2}')
+          Validators.pattern(/[a-zA-Z]{2}/)
         ],
         this.isDupeField("iso2")
       ],
       iso3: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{3}')
+          Validators.pattern(/[a-zA-Z]{3}/)
         ],
         this.isDupeField("iso3")
       ]

--- a/Chapter_11/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
+++ b/Chapter_11/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
@@ -51,11 +51,11 @@ export class CityEditComponent
       name: new FormControl('', Validators.required),
       lat: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       lon: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       countryId: new FormControl('', Validators.required)
     }, null, this.isDupeCity());

--- a/Chapter_11/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
+++ b/Chapter_11/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
@@ -48,14 +48,14 @@ export class CountryEditComponent
       iso2: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{2}')
+          Validators.pattern(/[a-zA-Z]{2}/)
         ],
         this.isDupeField("iso2")
       ],
       iso3: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{3}')
+          Validators.pattern(/[a-zA-Z]{3}/)
         ],
         this.isDupeField("iso3")
       ]

--- a/Chapter_12/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
+++ b/Chapter_12/WorldCities/ClientApp/src/app/cities/city-edit.component.ts
@@ -51,11 +51,11 @@ export class CityEditComponent
       name: new FormControl('', Validators.required),
       lat: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       lon: new FormControl('', [
         Validators.required,
-        Validators.pattern('^[-]?[0-9]+(\.[0-9]{1,4})?$')
+        Validators.pattern(/^[-]?[0-9]+(\.[0-9]{1,4})?$/)
       ]),
       countryId: new FormControl('', Validators.required)
     }, null, this.isDupeCity());

--- a/Chapter_12/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
+++ b/Chapter_12/WorldCities/ClientApp/src/app/countries/country-edit.component.ts
@@ -48,14 +48,14 @@ export class CountryEditComponent
       iso2: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{2}')
+          Validators.pattern(/[a-zA-Z]{2}/)
         ],
         this.isDupeField("iso2")
       ],
       iso3: ['',
         [
           Validators.required,
-          Validators.pattern('[a-zA-Z]{3}')
+          Validators.pattern(/[a-zA-Z]{3}/)
         ],
         this.isDupeField("iso3")
       ]


### PR DESCRIPTION
For better readability and highlighting support. Also, there's a slight performance improvement and the original regexes weren't properly escaped. 